### PR TITLE
Overlapping ships

### DIFF
--- a/lib/board.rb
+++ b/lib/board.rb
@@ -35,15 +35,11 @@ class Board
     end
 
     def cell_empty(coordinates)
-        return_value = false
-        
+        return_value = true
         coordinates.each do |coordinate|
-           
-            if @cells[coordinate].empty? == true
-                return_value = true
-           
+            if @cells[coordinate].empty? == false
+                return false
             end
-        #binding.pry
         end
         return_value
         

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -27,13 +27,26 @@ class Board
     end
 
     def valid_placement?(ship,coordinates)
-        if ship.length == coordinates.length && 
-            coordinates.map {|cell| cell.empty? == true} && 
-            consecutive_coordinates(coordinates)
+        if ship.length == coordinates.length && consecutive_coordinates(coordinates) && cell_empty(coordinates)
             true
         else
             false
         end
+    end
+
+    def cell_empty(coordinates)
+        return_value = false
+        
+        coordinates.each do |coordinate|
+           
+            if @cells[coordinate].empty? == true
+                return_value = true
+           
+            end
+        #binding.pry
+        end
+        return_value
+        
     end
 
     def consecutive_coordinates(coordinates)
@@ -42,7 +55,7 @@ class Board
         coordinates.each do |coordinate|
             rows << coordinate[0]
             columns << coordinate[1]
-
+        
         end
         if rows.uniq.length == 1
             return_value = true

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -15,8 +15,6 @@ RSpec.describe Board do
     describe "the cells board has" do
         it "has cell objects" do
             expect(@board.cells).to be_a(Hash)
-        end
-        it "" do
             expect(@board.cells.keys.length).to eq(16)
         end
     end
@@ -74,8 +72,9 @@ RSpec.describe Board do
         it 'can make sure there are no overlapping ships' do
             cruiser = Ship.new("Cruiser", 3)
 
-            @board.place(cruiser, ["A1", "A2", "A3"])
             expect(@board.valid_placement?(cruiser, ["A1", "A2", "A3"])).to be(true)
+            @board.place(cruiser, ["A1", "A2", "A3"])
+           
 
             submarine = Ship.new("Submarine", 2)
 

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -49,7 +49,6 @@ RSpec.describe Board do
             expect(@board.valid_placement?(submarine, ["A1", "A2"])).to be(true)
             expect(@board.valid_placement?(cruiser, ["B1", "C1", "D1"])).to be(true)
         end
-
         
     end
     describe "how it can place ships" do
@@ -69,6 +68,19 @@ RSpec.describe Board do
             expect(cell_3.ship).to eq(cruiser)
 
             expect(cell_3.ship == cell_2.ship).to eq(true)
+        end
+    end
+    describe "overlapping ships" do
+        it 'can make sure there are no overlapping ships' do
+            cruiser = Ship.new("Cruiser", 3)
+
+            @board.place(cruiser, ["A1", "A2", "A3"])
+            expect(@board.valid_placement?(cruiser, ["A1", "A2", "A3"])).to be(true)
+
+            submarine = Ship.new("Submarine", 2)
+
+            @board.valid_placement?(submarine, ["A1", "B1"])
+            expect(@board.valid_placement?(submarine, ["A1", "B1"])).to be(false)
         end
     end
 end


### PR DESCRIPTION
This branch adds a helper method "cell_empty" to the valid_placement? method in order to make sure a ship cannot be placed on a cell that already has another ship on it. Now anytime the valid_placement? method is called, in addition to checking that the length of the ship is the same as the number of coordinates and the coordinates are consecutive, it also checks that the cells of the coordinates are empty. If any of these conditions return false, it is not a valid placement. This addition to the method is tested and all tests pass